### PR TITLE
fix: improve footer visibility for copyright text and social links

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -181,11 +181,11 @@ const Footer = () => {
                         </form>
                     </div>
                 </div>
-                <div className="mt-10 pt-8 border-t border-gray-800 flex justify-between items-center">
+                <div className="mt-10 pt-8 border-t border-gray-800 flex flex-col items-center">
                     <p className="text-gray-400">
                         &copy; 2024 DecenTrade. All rights reserved. Powered by Open Source
                     </p>
-                    <div className="flex space-x-4">
+                    <div className="flex space-x-4 mt-2">
                         <a href="#" className="text-gray-400 hover:text-white transition-colors">
                             <FontAwesomeIcon icon={faTwitter} />
                         </a>


### PR DESCRIPTION
### What happened?
When scrolling down to the footer, the copyright text and social links are partially covered by the language change button and chat button, making them difficult to view.

### What was done
- Adjusted the layout and spacing of footer elements to ensure visibility.
- Centered 

### How to Test
1. Scroll down to the footer on any page.
2. Verify that the copyright text and social links are fully visible.
3. Ensure that the language change button and chat button no longer obstruct footer content.

### Additional Notes
This fix addresses the visibility issue but may require further adjustment if additional elements are added to the footer in the future.

### Video Demonstration
https://github.com/user-attachments/assets/0f5106b6-1de1-4fc3-b07c-47dc27d3eb2f

